### PR TITLE
Add option to disable fetching of mbedtls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,34 +20,38 @@ option(SIESTA_BUILD_DOCS "Build documentation for Siesta" ${SIESTA_STANDALONE})
 option(SIESTA_BUILD_EXAMPLES "Build examples for Siesta" ${SIESTA_STANDALONE})
 option(SIESTA_BUILD_TESTS "Build tests for Siesta" ${SIESTA_STANDALONE})
 option(SIESTA_ENABLE_TLS "Set to ON to enable the secure Siesta server" OFF)
+option(SIESTA_FETCH_MBEDTLS "Set to ON to automatically fetch mbedtls (if tls enabled)" ON)
+
 if (SIESTA_ENABLE_TLS)
-    include(FetchContent)
-    FetchContent_Declare(
-        mbedtls
-        URL      https://tls.mbed.org/download/mbedtls-2.16.3-apache.tgz
-        URL_HASH SHA1=dce8550f8f9465f3aea44cb7d0f9d0ba8140034a
-    )
-    FetchContent_GetProperties(mbedtls)
-    if(NOT mbedtls_POPULATED)
-        message("Setting up ARM mbedTLS...")
-        FetchContent_Populate(mbedtls)
-        set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
-        set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
-        set(INSTALL_MBEDTLS_HEADERS OFF CACHE BOOL "" FORCE)
-        add_subdirectory(${mbedtls_SOURCE_DIR} ${mbedtls_BINARY_DIR})
-        target_include_directories(mbedtls PUBLIC $<BUILD_INTERFACE:${mbedtls_SOURCE_DIR}/include>)
-        install (TARGETS mbedtls mbedx509 mbedcrypto
-            EXPORT nng-target
-            FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Tools
+    if(SIESTA_FETCH_MBEDTLS)
+        include(FetchContent)
+        FetchContent_Declare(
+            mbedtls
+            URL      https://tls.mbed.org/download/mbedtls-2.16.3-apache.tgz
+            URL_HASH SHA1=dce8550f8f9465f3aea44cb7d0f9d0ba8140034a
         )
-        set_target_properties(
-            apidoc mbedtls mbedx509 mbedcrypto lib
-            PROPERTIES
-            FOLDER "Third-Party/mbedTLS"
-        )
+        FetchContent_GetProperties(mbedtls)
+        if(NOT mbedtls_POPULATED)
+            message("Setting up ARM mbedTLS...")
+            FetchContent_Populate(mbedtls)
+            set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+            set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+            set(INSTALL_MBEDTLS_HEADERS OFF CACHE BOOL "" FORCE)
+            add_subdirectory(${mbedtls_SOURCE_DIR} ${mbedtls_BINARY_DIR})
+            target_include_directories(mbedtls PUBLIC $<BUILD_INTERFACE:${mbedtls_SOURCE_DIR}/include>)
+            install (TARGETS mbedtls mbedx509 mbedcrypto
+                EXPORT nng-target
+                FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Library
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Tools
+            )
+            set_target_properties(
+                apidoc mbedtls mbedx509 mbedcrypto lib
+                PROPERTIES
+                FOLDER "Third-Party/mbedTLS"
+            )
+        endif()
     endif()
     set(NNG_ENABLE_TLS ON CACHE BOOL "" FORCE)
 else()


### PR DESCRIPTION
If fetching is disabled mbedtls is expected to be provided by the consumer in some other way.