### PR TITLE
Fix regex match replacement crash on ARM due to iterator type mismatch

### DIFF
--- a/siesta/src/server.cpp
+++ b/siesta/src/server.cpp
@@ -626,8 +626,21 @@ zFX5yAtcD5BnoPBo0CE5y/I=
             std::smatch m;
             while (std::regex_search(uri_re, m, re_param)) {
                 r.uri_param_key.push_back(m[1].str());
-                uri_re.replace(
-                    m[0].first - uri_re.begin(), m[0].length(), "([^/]+)");
+
+                if (m.ready() && m.size() > 0) {
+                    // Compute the position of the match within uri_re using const_iterator
+                    // to avoid type mismatch errors between const and non-const iterators.
+                    // This is particularly important on ARM platforms, where the standard library
+                    // (e.g., libstdc++) enforces stricter type checks and may represent iterators differently.
+                    // Avoid subtracting iterators directly, as it may lead to undefined behavior
+                    // if the iterator types don't match exactly or the source string differs.
+                    auto pos = std::distance(uri_re.cbegin(), m[0].first);
+                
+                    // Replace the matched parameter (e.g., ":param-id") with a regex group
+                    // that matches any non-slash segment, allowing for dynamic route matching.
+                    uri_re.replace(pos, m[0].length(), "([^/]+)");
+                }
+                
             }
             std::regex re(uri_re);
             r.reg_exp = std::move(re);


### PR DESCRIPTION
Refactored the computation of the match position in uri_re to use const_iterator with std::distance. This ensures type safety between const and non-const iterators, especially relevant on ARM platforms, where standard library implementations (like libstdc++) enforce stricter iterator type checks. This change prevents potential undefined behavior from direct iterator subtraction across mismatched types and improves portability. Also clarified the regex replacement logic for dynamic route matching.