### PR TITLE
Fix/http handler rel path

### DIFF
--- a/siesta/include/siesta/client.h
+++ b/siesta/include/siesta/client.h
@@ -17,6 +17,10 @@ namespace siesta
         NO_DISCARD Response getRequest(const std::string& address,
                                        const Headers& headers = Headers(),
                                        const int timeout_ms   = 1000);
+        // Uses the raw path without any canonicalization
+        NO_DISCARD Response getRequestRawUri(const std::string& address,
+                                             const Headers& headers = Headers(),
+                                             const int timeout_ms   = 1000);
         NO_DISCARD Response putRequest(const std::string& uri,
                                        const std::string& body,
                                        const std::string& content_type,

--- a/siesta/include/siesta/common.h
+++ b/siesta/include/siesta/common.h
@@ -110,7 +110,7 @@ namespace siesta
     {
         nng_type* obj{nullptr};
         nng_free_function fn_free;
-        void release()
+        void remove()
         {
             if (obj != nullptr) {
                 fn_free(obj);
@@ -128,16 +128,25 @@ namespace siesta
         {
             other.obj = nullptr;
         }
-        ~nng_smart_ptr() { release(); }
+        ~nng_smart_ptr() { remove(); }
         nng_smart_ptr& operator=(nng_type* new_obj)
         {
-            release();
+            remove();
             obj = new_obj;
             return *this;
         }
         nng_type** operator&() { return &obj; }
         operator nng_type*() const { return obj; }
         nng_type* operator->() { return obj; }
+
+        nng_type* release()
+        {
+            auto ret = obj;
+            obj      = nullptr;
+            return ret;
+        }
     };
+
+    std::string lookup_content_type(const std::string& file_extension);
 
 }  // namespace siesta

--- a/siesta/src/client.cpp
+++ b/siesta/src/client.cpp
@@ -32,11 +32,28 @@ namespace
         const std::string& address,
         const std::string& body,
         const std::string& content_type,
-        const int timeout_ms)
+        const int timeout_ms,
+        const bool raw_uri)
     {
         auto f = std::async(std::launch::async, [=]() -> std::string {
             nng_smart_ptr<nng_url> url(nng_url_free);
             nng_call(nng_url_parse, &url, address.c_str());
+            if (raw_uri) {
+                // Copy the path verbatim (used in tests)
+                std::string raw = url->u_rawurl;
+                auto pos        = raw.find(url->u_hostname);
+                if (pos != std::string::npos) {
+                    pos = raw.find_first_of('/', pos);
+                    if (pos != std::string::npos) {
+                        auto path = raw.substr(pos);
+                        // Replace the old strings in nng_url object
+                        nng_strfree(url->u_path);
+                        nng_strfree(url->u_requri);
+                        url->u_path   = nng_strdup(path.c_str());
+                        url->u_requri = nng_strdup(path.c_str());
+                    }
+                }
+            }
 
             nng_smart_ptr<nng_http_client> client(nng_http_client_free);
             nng_call(nng_http_client_alloc, &client, url);
@@ -306,7 +323,17 @@ Response siesta::client::getRequest(const std::string& address,
                                     const Headers& headers /*= Headers()*/,
                                     const int timeout_ms /*= 1000*/)
 {
-    return doRequest(HttpMethod::GET, headers, address, "", "", timeout_ms);
+    return doRequest(
+        HttpMethod::GET, headers, address, "", "", timeout_ms, false);
+}
+
+NO_DISCARD Response
+siesta::client::getRequestRawUri(const std::string& address,
+                                 const Headers& headers /*= Headers()*/,
+                                 const int timeout_ms /*= 1000*/)
+{
+    return doRequest(
+        HttpMethod::GET, headers, address, "", "", timeout_ms, true);
 }
 
 Response siesta::client::putRequest(const std::string& uri,
@@ -316,7 +343,7 @@ Response siesta::client::putRequest(const std::string& uri,
                                     const int timeout_ms /*= 1000*/)
 {
     return doRequest(
-        HttpMethod::PUT, headers, uri, body, content_type, timeout_ms);
+        HttpMethod::PUT, headers, uri, body, content_type, timeout_ms, false);
 }
 
 Response siesta::client::postRequest(const std::string& uri,
@@ -326,14 +353,14 @@ Response siesta::client::postRequest(const std::string& uri,
                                      const int timeout_ms /*= 1000*/)
 {
     return doRequest(
-        HttpMethod::POST, headers, uri, body, content_type, timeout_ms);
+        HttpMethod::POST, headers, uri, body, content_type, timeout_ms, false);
 }
 
 Response siesta::client::deleteRequest(const std::string& uri,
                                        const Headers& headers /*= Headers()*/,
                                        const int timeout_ms /*= 1000*/)
 {
-    return doRequest(HttpMethod::DEL, headers, uri, "", "", timeout_ms);
+    return doRequest(HttpMethod::DEL, headers, uri, "", "", timeout_ms, false);
 }
 
 Response siesta::client::patchRequest(const std::string& uri,
@@ -343,7 +370,7 @@ Response siesta::client::patchRequest(const std::string& uri,
                                       const int timeout_ms /*= 1000*/)
 {
     return doRequest(
-        HttpMethod::PATCH, headers, uri, body, content_type, timeout_ms);
+        HttpMethod::PATCH, headers, uri, body, content_type, timeout_ms, false);
 }
 
 std::unique_ptr<siesta::client::websocket::Writer>

--- a/siesta/src/server.cpp
+++ b/siesta/src/server.cpp
@@ -8,6 +8,8 @@
 #include <siesta/server.h>
 
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -28,6 +30,7 @@
 using namespace siesta;
 using namespace siesta::server;
 using siesta::nng_smart_ptr;
+namespace fs = std::filesystem;
 
 namespace
 {
@@ -390,18 +393,23 @@ zFX5yAtcD5BnoPBo0CE5y/I=
         struct directory {
             nng_http_server* server_;
             nng_smart_ptr<nng_http_handler> handler{nng_http_handler_free};
+            const fs::path path_;
             directory(nng_http_server* server,
                       const std::string& uri,
                       const std::string& path)
-                : server_(server)
+                : server_(server), path_(fs::absolute(path))
             {
                 int rv;
-                if ((rv = nng_http_handler_alloc_directory(
-                         &handler, uri.c_str(), path.c_str())) != 0) {
+                if ((rv = nng_http_handler_alloc(
+                         &handler, uri.c_str(), handler_fn)) != 0) {
                     fatal("nng_http_handler_alloc", rv);
                 }
                 if ((rv = nng_http_handler_set_tree(handler)) != 0) {
                     fatal("nng_http_handler_set_tree", rv);
+                }
+                if ((rv = nng_http_handler_set_data(handler, this, NULL)) !=
+                    0) {
+                    fatal("nng_http_handler_add_handler", rv);
                 }
                 if ((rv = nng_http_server_add_handler(server_, handler)) != 0) {
                     fatal("nng_http_handler_add_handler", rv);
@@ -409,6 +417,75 @@ zFX5yAtcD5BnoPBo0CE5y/I=
             }
             ~directory() { nng_http_server_del_handler(server_, handler); }
             std::map<std::string, std::string> additional_headers;
+
+            // Using our own file handler due to nng issues with relative URIs
+            static void handler_fn(nng_aio* aio)
+            {
+                nng_http_req* req = (nng_http_req*)nng_aio_get_input(aio, 0);
+                nng_http_handler* h =
+                    (nng_http_handler*)nng_aio_get_input(aio, 1);
+                int rv;
+                nng_smart_ptr<nng_http_res> res{nng_http_res_free};
+                if ((rv = nng_http_res_alloc(&res)) != 0) {
+                    nng_aio_finish(aio, rv);
+                    return;
+                }
+
+                const auto* hf = (directory*)nng_http_handler_get_data(h);
+                auto path      = hf->path_;
+                path.concat(nng_http_req_get_uri(req));
+                path = fs::canonical(path);
+
+                try {
+                    // Make sure base path is part of path
+                    if (path.string().find(hf->path_.string()) != 0) {
+                        throw siesta::Exception(
+                            siesta::HttpStatus::BAD_REQUEST);
+                    }
+
+                    if (fs::is_directory(path)) {
+                        path.concat("index.html");
+                    }
+
+                    if (!fs::is_regular_file(path)) {
+                        throw siesta::Exception(siesta::HttpStatus::NOT_FOUND);
+                    }
+
+                    auto ctype = lookup_content_type(path.extension().string());
+
+                    std::ifstream is(path, std::ios::binary | std::ios::ate);
+                    if (!is.is_open()) {
+                        throw siesta::Exception(
+                            siesta::HttpStatus::INTERNAL_SERVER_ERROR,
+                            "file read error");
+                    }
+                    auto fileSize = is.tellg();
+                    is.seekg(std::ios::beg);
+                    std::string content(fileSize, 0);
+                    is.read(&content[0], fileSize);
+
+                    if (((rv = nng_http_res_set_status(
+                              res, NNG_HTTP_STATUS_OK)) != 0) ||
+                        ((rv = nng_http_res_set_header(
+                              res, "Content-Type", ctype.c_str())) != 0) ||
+                        ((rv = nng_http_res_copy_data(
+                              res, content.data(), content.size())) != 0)) {
+                        nng_aio_finish(aio, rv);
+                        return;
+                    }
+
+                } catch (siesta::Exception& e) {
+                    nng_http_res_set_data(res, NULL, 0);
+                    nng_http_res_set_status(res, (uint16_t)e.status());
+                    if (e.has_reason()) {
+                        nng_http_res_set_reason(res, e.what());
+                    } else {
+                        nng_http_res_set_reason(res, NULL);
+                    }
+                }
+                nng_aio_set_output(aio, 0, res.release());
+                nng_aio_finish(aio, 0);
+            }
         };
 
         struct web_socket {
@@ -965,6 +1042,47 @@ namespace siesta
             }
         }
         throw std::runtime_error("method '" + method + "' not found");
+    }
+
+    std::string lookup_content_type(const std::string& file_extension)
+    {
+        // Copied from nng http_server.c
+        static const std::map<std::string, std::string> ext_2_content = {
+            {".ai", "application/postscript"},
+            {".aif", "audio/aiff"},
+            {".aiff", "audio/aiff"},
+            {".avi", "video/avi"},
+            {".au", "audio/basic"},
+            {".bin", "application/octet-stream"},
+            {".bmp", "image/bmp"},
+            {".css", "text/css"},
+            {".eps", "application/postscript"},
+            {".gif", "image/gif"},
+            {".htm", "text/html"},
+            {".html", "text/html"},
+            {".ico", "image/x-icon"},
+            {".jpeg", "image/jpeg"},
+            {".jpg", "image/jpeg"},
+            {".js", "application/javascript"},
+            {".md", "text/markdown"},
+            {".mp2", "video/mpeg"},
+            {".mp3", "audio/mpeg3"},
+            {".mpeg", "video/mpeg"},
+            {".mpg", "video/mpeg"},
+            {".pdf", "application/pdf"},
+            {".png", "image/png"},
+            {".ps", "application/postscript"},
+            {".rtf", "text/rtf"},
+            {".text", "text/plain"},
+            {".tif", "image/tiff"},
+            {".tiff", "image/tiff"},
+            {".txt", "text/plain"},
+            {".wav", "audio/wav"}};
+        auto it = ext_2_content.find(file_extension);
+        if (it == ext_2_content.end()) {
+            return "text/plain";
+        }
+        return it->second;
     }
 
     namespace server


### PR DESCRIPTION
Since nng http handler "allows" relative paths, it's no longer used for serving folders in siesta.